### PR TITLE
add permission edit button

### DIFF
--- a/client/components/Permissions/PermissionDialog.jsx
+++ b/client/components/Permissions/PermissionDialog.jsx
@@ -30,6 +30,7 @@ export default class PermissionDialog extends Component {
         <PermissionForm
           applications={applications.records} loading={permission.loading} initialValues={permission.record} validationErrors={permission.validationErrors}
           onClose={this.props.onClose} onSubmit={this.props.onSave}
+          isNew={permission.isNew}
         >
           <Error message={permission.error} />
         </PermissionForm>

--- a/client/components/Permissions/PermissionForm.jsx
+++ b/client/components/Permissions/PermissionForm.jsx
@@ -13,11 +13,12 @@ export default createForm('permission', class extends Component {
     handleSubmit: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     applications: PropTypes.object.isRequired,
+    isNew: PropTypes.bool,
     children: PropTypes.node
   };
 
   render() {
-    const { handleSubmit, loading, submitting, validationErrors } = this.props;
+    const { handleSubmit, loading, submitting, validationErrors, isNew } = this.props;
     const applications = this.props.applications.map(app => ({
       value: app.client_id,
       text: `${app.name}`
@@ -49,7 +50,7 @@ export default createForm('permission', class extends Component {
         </Modal.Body>
         <Modal.Footer>
           <Button bsSize="large" disabled={loading || submitting} onClick={this.props.onClose}> Cancel </Button>
-          <Button bsStyle="primary" bsSize="large" disabled={loading || submitting} onClick={handleSubmit}> Create </Button>
+          <Button bsStyle="primary" bsSize="large" disabled={loading || submitting} onClick={handleSubmit}> { isNew ? 'Create' : 'Save' } </Button>
         </Modal.Footer>
       </div>
     );

--- a/client/components/Permissions/PermissionsOverview.jsx
+++ b/client/components/Permissions/PermissionsOverview.jsx
@@ -74,6 +74,10 @@ export default class PermissionsOverview extends Component {
   renderPermissionActions = (permission) => (
     <div>
       <TableAction
+        id={`edit-${permission._id}`} title="Edit Permission" icon="274"
+        onClick={this.props.editPermission} args={[ permission ]} disabled={this.props.permissions.get('loading') || false}
+      />
+      <TableAction
         id={`delete-${permission._id}`} type="default" title="Delete Permission" icon="471"
         onClick={this.props.requestDeletePermission} args={[ permission ]} disabled={this.props.permissions.get('loading') || false}
       />

--- a/server/lib/storage/database.js
+++ b/server/lib/storage/database.js
@@ -36,13 +36,14 @@ export default class Database {
     return { size: null, type: config('DB_TYPE') };
   }
 
-  canDeleteRecord(type, checkFor, id) {
+  canTouchRecord(type, checkFor, id) {
+    console.log('type:', type, 'checkFor:', checkFor, 'id:', id)
     return this.provider.getAll(type)
       .then(items => _.filter(items, item => item[checkFor] && _.includes(item[checkFor], id)))
       .then(items => {
         if (items.length) {
           const names = items.map(item => item.name).join(', ');
-          const message = `Unable to delete ${checkFor} while used in ${type}: ${names}`;
+          const message = `Unable to touch ${checkFor} while used in ${type}: ${names}`;
           return Promise.reject(new ValidationError(message));
         }
         return Promise.resolve();
@@ -98,11 +99,13 @@ export default class Database {
           `Permission with name "${permission.name}" already exists for this application`,
           id
         ))
+      .then(() => this.canTouchRecord('roles', 'permissions', id))
+      .then(() => this.canTouchRecord('groups', 'permissions', id))
       .then(() => this.provider.update('permissions', id, permission));
   }
 
   deletePermission(id) {
-    return this.canDeleteRecord('roles', 'permissions', id)
+    return this.canTouchRecord('roles', 'permissions', id)
       .then(() => this.provider.delete('permissions', id));
   }
 
@@ -138,7 +141,7 @@ export default class Database {
   }
 
   deleteRole(id) {
-    return this.canDeleteRecord('groups', 'roles', id)
+    return this.canTouchRecord('groups', 'roles', id)
       .then(() => this.provider.delete('roles', id));
   }
 

--- a/server/lib/storage/database.js
+++ b/server/lib/storage/database.js
@@ -37,7 +37,6 @@ export default class Database {
   }
 
   canTouchRecord(type, checkFor, id) {
-    console.log('type:', type, 'checkFor:', checkFor, 'id:', id)
     return this.provider.getAll(type)
       .then(items => _.filter(items, item => item[checkFor] && _.includes(item[checkFor], id)))
       .then(items => {

--- a/server/lib/storage/database.js
+++ b/server/lib/storage/database.js
@@ -36,7 +36,7 @@ export default class Database {
     return { size: null, type: config('DB_TYPE') };
   }
 
-  canTouchRecord(type, checkFor, id) {
+  canChange(type, checkFor, id) {
     return this.provider.getAll(type)
       .then(items => _.filter(items, item => item[checkFor] && _.includes(item[checkFor], id)))
       .then(items => {
@@ -98,13 +98,13 @@ export default class Database {
           `Permission with name "${permission.name}" already exists for this application`,
           id
         ))
-      .then(() => this.canTouchRecord('roles', 'permissions', id))
-      .then(() => this.canTouchRecord('groups', 'permissions', id))
+      .then(() => this.canChange('roles', 'permissions', id))
+      .then(() => this.canChange('groups', 'permissions', id))
       .then(() => this.provider.update('permissions', id, permission));
   }
 
   deletePermission(id) {
-    return this.canTouchRecord('roles', 'permissions', id)
+    return this.canChange('roles', 'permissions', id)
       .then(() => this.provider.delete('permissions', id));
   }
 
@@ -140,7 +140,7 @@ export default class Database {
   }
 
   deleteRole(id) {
-    return this.canTouchRecord('groups', 'roles', id)
+    return this.canChange('groups', 'roles', id)
       .then(() => this.provider.delete('roles', id));
   }
 

--- a/tests/server/permissions-route.tests.js
+++ b/tests/server/permissions-route.tests.js
@@ -18,7 +18,7 @@ describe('permissions-route', () => {
   };
 
   before((done) => {
-    db.canDeleteRecord = () => Promise.resolve();
+    db.canTouchRecord = () => Promise.resolve();
     db.getPermissions = () => Promise.resolve([ permission ]);
     db.getPermission = () => Promise.resolve(permission);
     done();

--- a/tests/server/permissions-route.tests.js
+++ b/tests/server/permissions-route.tests.js
@@ -18,7 +18,7 @@ describe('permissions-route', () => {
   };
 
   before((done) => {
-    db.canTouchRecord = () => Promise.resolve();
+    db.canChange = () => Promise.resolve();
     db.getPermissions = () => Promise.resolve([ permission ]);
     db.getPermission = () => Promise.resolve(permission);
     done();

--- a/tests/server/roles-route.tests.js
+++ b/tests/server/roles-route.tests.js
@@ -25,7 +25,7 @@ describe('roles-route', () => {
   };
 
   before((done) => {
-    db.canTouchRecord = () => Promise.resolve();
+    db.canChange = () => Promise.resolve();
     db.getPermissions = () => Promise.resolve([ permission ]);
     db.getRoles = () => Promise.resolve([ role ]);
     db.getRole = () => Promise.resolve(role);

--- a/tests/server/roles-route.tests.js
+++ b/tests/server/roles-route.tests.js
@@ -25,7 +25,7 @@ describe('roles-route', () => {
   };
 
   before((done) => {
-    db.canDeleteRecord = () => Promise.resolve();
+    db.canTouchRecord = () => Promise.resolve();
     db.getPermissions = () => Promise.resolve([ permission ]);
     db.getRoles = () => Promise.resolve([ role ]);
     db.getRole = () => Promise.resolve(role);


### PR DESCRIPTION
Test Case
1. Permissions - add permission for app X
2. Roles - add role for app X
3. Roles - add permission created
4. Permissions - change app X to app Y
5. Roles - confirm that permission is no longer in permission options
6. Permissions - change app Y to app X again
7. Roles - permission is again on options, and it’s selected > this must happen?!
    - should it be unselected?
    - OR should it be possible to change application in permissions?

