### PR TITLE
fix data searching cleared

### DIFF
--- a/client/components/Groups/GroupsOverview.jsx
+++ b/client/components/Groups/GroupsOverview.jsx
@@ -68,14 +68,6 @@ class GroupsOverview extends React.Component {
     );
   }
 
-  renderLoading() {
-    return (
-      <div className="spinner spinner-lg is-auth0" style={{ margin: '200px auto 0' }}>
-        <div className="circle" />
-      </div>
-    );
-  }
-
   renderEmptyState() {
     return (
       <BlankState
@@ -152,8 +144,6 @@ class GroupsOverview extends React.Component {
     const { error, loading, records, fetchQuery } = this.props.groups;
     const users = this.props.users;
 
-    if (loading) { return this.renderLoading(); }
-
     return (
       <div>
         <GroupDialog group={this.props.group} onSave={this.props.save} onClose={this.clear} />
@@ -167,7 +157,7 @@ class GroupsOverview extends React.Component {
           fetchUsers={this.props.fetchUsers}
         />
 
-        { !error && !records.size && (!fetchQuery || !fetchQuery.length) ? this.renderEmptyState() : this.renderBody() }
+        { !error && !records.size && !loading && (!fetchQuery || !fetchQuery.length) ? this.renderEmptyState() : this.renderBody() }
       </div>
     );
   }

--- a/client/components/Permissions/PermissionsOverview.jsx
+++ b/client/components/Permissions/PermissionsOverview.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { Button } from 'react-bootstrap';
-import { Error, TableAction, SectionHeader, BlankState, SearchBar } from 'auth0-extension-ui';
+import { Error, TableAction, SectionHeader, BlankState, SearchBar, LoadingPanel } from 'auth0-extension-ui';
 
 import { PermissionDeleteDialog, PermissionDialog, PermissionsTable } from './';
 import PermissionsIcon from '../Icons/PermissionsIcon';
@@ -108,14 +108,6 @@ export default class PermissionsOverview extends Component {
     );
   }
 
-  renderLoading() {
-    return (
-      <div className="spinner spinner-lg is-auth0" style={{ margin: '200px auto 0' }}>
-        <div className="circle" />
-      </div>
-    );
-  }
-
   renderEmptyState() {
     return (
       <BlankState
@@ -140,14 +132,12 @@ export default class PermissionsOverview extends Component {
   render() {
     const { error, loading, records, fetchQuery } = this.props.permissions.toJS();
 
-    if (loading) { return this.renderLoading(); }
-
     return (
       <div>
         <PermissionDialog applications={this.props.applications} permission={this.props.permission} onSave={this.props.savePermission} onClose={this.props.clearPermission} />
         <PermissionDeleteDialog permission={this.props.permission} onCancel={this.props.cancelDeletePermission} onConfirm={this.props.deletePermission} />
 
-        { !error && !records.length && (!fetchQuery || !fetchQuery.length) ? this.renderEmptyState() : (
+        { !error && !records.length && !loading && (!fetchQuery || !fetchQuery.length) ? this.renderEmptyState() : (
           <div>
             <SectionHeader
               title="Permissions"
@@ -161,7 +151,9 @@ export default class PermissionsOverview extends Component {
             <div className="row">
               <div className="col-xs-12">
                 <Error message={error} />
-                {this.renderBody(records, loading)}
+                <LoadingPanel show={loading}>
+                  {this.renderBody(records, loading)}
+                </LoadingPanel>
               </div>
             </div>
           </div>

--- a/client/components/Roles/RolesOverview.jsx
+++ b/client/components/Roles/RolesOverview.jsx
@@ -89,14 +89,6 @@ export default class RolesOverview extends Component {
     );
   }
 
-  renderLoading() {
-    return (
-      <div className="spinner spinner-lg is-auth0" style={{ margin: '200px auto 0' }}>
-        <div className="circle" />
-      </div>
-    );
-  }
-
   renderEmptyState() {
     return (
       <BlankState
@@ -121,14 +113,12 @@ export default class RolesOverview extends Component {
   render() {
     const { error, loading, records, fetchQuery } = this.props.roles.toJS();
 
-    if (loading) { return this.renderLoading(); }
-
     return (
       <div>
         <RoleDialog onApplicationSelected={this.props.roleApplicationSelected} applications={this.props.applications} permissions={this.props.permissions} role={this.props.role} onSave={this.props.saveRole} onClose={this.props.clearRole} />
         <RoleDeleteDialog role={this.props.role} onCancel={this.props.cancelDeleteRole} onConfirm={this.props.deleteRole} />
 
-        { !error && !records.length && (!fetchQuery || !fetchQuery.length) ? this.renderEmptyState() : (
+        { !error && !records.length && !loading && (!fetchQuery || !fetchQuery.length) ? this.renderEmptyState() : (
           <div>
             <SectionHeader title="Roles" description="Create and manage Roles (collection of permissions) for your applications which can then be added to groups.">
               <Button bsStyle="success" onClick={this.props.createRole} disabled={loading}>

--- a/client/components/Users/UserOverview.jsx
+++ b/client/components/Users/UserOverview.jsx
@@ -96,20 +96,20 @@ class UserOverview extends React.Component {
         <Error message={error} />
         <SectionHeader title="Users" description="Here you will find all the users." />
 
-        <LoadingPanel show={loading}>
-          <UserGeneral />
-          <div className="row" style={{ marginBottom: '20px' }}>
-            <div className="col-xs-12">
-              <SearchBar
-                placeholder="Search for users"
-                searchOptions={this.searchBarOptions}
-                handleKeyPress={this.onKeyPress}
-                handleReset={this.onReset}
-                handleOptionChange={this.onHandleOptionChange}
-              />
-            </div>
+        <UserGeneral />
+        <div className="row" style={{ marginBottom: '20px' }}>
+          <div className="col-xs-12">
+            <SearchBar
+              placeholder="Search for users"
+              searchOptions={this.searchBarOptions}
+              handleKeyPress={this.onKeyPress}
+              handleReset={this.onReset}
+              handleOptionChange={this.onHandleOptionChange}
+            />
           </div>
+        </div>
 
+        <LoadingPanel show={loading}>
           <div className="row">
             <div className="col-xs-12">
               <UsersTable loading={loading} users={users} renderActions={renderActions} />


### PR DESCRIPTION
This approach just saves searchbar input when user does a query, but once it changes to another page (e.g roles, permissions or groups), results are forgotten (despite the fact search is filtered)

A work-in-progress solution to save the search information when user come back to that page, is in this branch https://github.com/auth0/auth0-authorization-extension/compare/dev...sericaia:fix-data-searching?expand=1 but we need to evaluate right now if this is required and how urgent it is