### PR TITLE
Endpoints for userId management

### DIFF
--- a/server/api/users/routes/delete_user.js
+++ b/server/api/users/routes/delete_user.js
@@ -1,0 +1,27 @@
+import Joi from 'joi';
+
+import { removeUserId } from '../../../lib/queries';
+
+module.exports = (server) => ({
+  method: 'DELETE',
+  path: '/api/users/{id}',
+  config: {
+    auth: {
+      strategies: [ 'jwt' ],
+      scope: [ 'update:groups' ]
+    },
+    description: 'Remove user ID from the storage.',
+    validate: {
+      params: {
+        id: Joi.string().required()
+      }
+    },
+    pre: [
+      server.handlers.managementClient
+    ]
+  },
+  handler: (req, reply) =>
+    removeUserId(req.storage, req.params.id)
+      .then(user => reply(user))
+      .catch(err => reply.error(err))
+});

--- a/server/api/users/routes/delete_user.js
+++ b/server/api/users/routes/delete_user.js
@@ -22,6 +22,6 @@ module.exports = (server) => ({
   },
   handler: (req, reply) =>
     removeUserId(req.storage, req.params.id)
-      .then(user => reply(user))
+      .then(() => reply().code(204))
       .catch(err => reply.error(err))
 });

--- a/server/api/users/routes/patch_user.js
+++ b/server/api/users/routes/patch_user.js
@@ -1,0 +1,28 @@
+import Joi from 'joi';
+
+import { updateUserId } from '../../../lib/queries';
+
+module.exports = (server) => ({
+  method: 'PATCH',
+  path: '/api/users/{id}/{newId}',
+  config: {
+    auth: {
+      strategies: [ 'jwt' ],
+      scope: [ 'update:groups' ]
+    },
+    description: 'Update user ID in the storage. In case of account linking, for instance',
+    validate: {
+      params: {
+        id: Joi.string().required(),
+        newId: Joi.string().required()
+      }
+    },
+    pre: [
+      server.handlers.managementClient
+    ]
+  },
+  handler: (req, reply) =>
+    updateUserId(req.storage, req.params.id, req.params.newId)
+      .then(user => reply(user))
+      .catch(err => reply.error(err))
+});

--- a/server/api/users/routes/patch_user.js
+++ b/server/api/users/routes/patch_user.js
@@ -23,6 +23,6 @@ module.exports = (server) => ({
   },
   handler: (req, reply) =>
     updateUserId(req.storage, req.params.id, req.params.newId)
-      .then(user => reply(user))
+      .then(() => reply().code(204))
       .catch(err => reply.error(err))
 });

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -436,9 +436,14 @@ const updateUserInGroups = (db, id, newId) =>
   getAllUserGroups(db, id)
     .then(groups => Promise.map(groups, group => {
       const groupId = group._id;
-      const index = group.members.indexOf(id);
-      group.members[index] = newId; // eslint-disable-line no-param-reassign
-      group.members = _.uniq(group.members); // eslint-disable-line no-param-reassign
+
+      if (newId) {
+        const index = group.members.indexOf(id);
+        group.members[index] = newId; // eslint-disable-line no-param-reassign
+        group.members = _.uniq(group.members); // eslint-disable-line no-param-reassign
+      } else {
+        _.pull(group.members, id);
+      }
 
       return db.updateGroup(groupId, group);
     }));
@@ -447,25 +452,16 @@ const updateUserInRoles = (db, id, newId) =>
   getAllUserRoles(db, id)
     .then(roles => Promise.map(roles, role => {
       const roleId = role._id;
-      const index = role.users.indexOf(id);
-      role.users[index] = newId; // eslint-disable-line no-param-reassign
-      role.users = _.uniq(role.users); // eslint-disable-line no-param-reassign
+
+      if (newId) {
+        const index = role.users.indexOf(id);
+        role.users[index] = newId; // eslint-disable-line no-param-reassign
+        role.users = _.uniq(role.users); // eslint-disable-line no-param-reassign
+      } else {
+        _.pull(role.users, id);
+      }
 
       return db.updateRole(roleId, role);
-    }));
-
-const removeUserFromGroups = (db, id) =>
-  getAllUserGroups(db, id)
-    .then(groups => Promise.map(groups, group => {
-      _.pull(group.members, id);
-      return db.updateGroup(group._id, group);
-    }));
-
-const removeUserFromRoles = (db, id) =>
-  getAllUserRoles(db, id)
-    .then(roles => Promise.map(roles, role => {
-      _.pull(role.users, id);
-      return db.updateRole(role._id, role);
     }));
 
 /*
@@ -480,7 +476,7 @@ export function updateUserId(db, id, newId) {
  * Removes userId from all groups and roles
  */
 export function removeUserId(db, id) {
-  return removeUserFromGroups(db, id)
-    .then(() => removeUserFromRoles(db, id));
+  return updateUserInGroups(db, id)
+    .then(() => updateUserInRoles(db, id));
 }
 

--- a/server/plugins/routes.js
+++ b/server/plugins/routes.js
@@ -48,6 +48,8 @@ module.exports.register = (server, options, next) => {
   server.route(require('../api/metadata/routes/get_metadata')(server));
   server.route(require('../api/users/routes/get_user')(server));
   server.route(require('../api/users/routes/get_users')(server));
+  server.route(require('../api/users/routes/patch_user')(server));
+  server.route(require('../api/users/routes/delete_user')(server));
   server.route(require('../api/users-groups/routes/get_users_groups')(server));
   server.route(require('../api/users-groups/routes/get_users_groups_calculate')(server));
   server.route(require('../api/users-groups/routes/patch_user_add_to_group')(server));

--- a/tests/unit/client/reducers/applications.tests.js
+++ b/tests/unit/client/reducers/applications.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { applications } from '../../../client/reducers/applications';
-import * as constants from '../../../client/constants';
+import { applications } from '../../../../client/reducers/applications';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/auth.tests.js
+++ b/tests/unit/client/reducers/auth.tests.js
@@ -1,7 +1,7 @@
 import url from 'url';
 import expect from 'expect';
-import { auth } from '../../../client/reducers/auth';
-import * as constants from '../../../client/constants';
+import { auth } from '../../../../client/reducers/auth';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   error: null,

--- a/tests/unit/client/reducers/configuration.tests.js
+++ b/tests/unit/client/reducers/configuration.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { configuration } from '../../../client/reducers/configuration';
-import * as constants from '../../../client/constants';
+import { configuration } from '../../../../client/reducers/configuration';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/connections.tests.js
+++ b/tests/unit/client/reducers/connections.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { connections } from '../../../client/reducers/connections';
-import * as constants from '../../../client/constants';
+import { connections } from '../../../../client/reducers/connections';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/group.tests.js
+++ b/tests/unit/client/reducers/group.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { group } from '../../../client/reducers/group';
-import * as constants from '../../../client/constants';
+import { group } from '../../../../client/reducers/group';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/groupMapping.tests.js
+++ b/tests/unit/client/reducers/groupMapping.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { groupMapping } from '../../../client/reducers/groupMapping';
-import * as constants from '../../../client/constants';
+import { groupMapping } from '../../../../client/reducers/groupMapping';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/groupMember.tests.js
+++ b/tests/unit/client/reducers/groupMember.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { groupMember } from '../../../client/reducers/groupMember';
-import * as constants from '../../../client/constants';
+import { groupMember } from '../../../../client/reducers/groupMember';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   error: null,

--- a/tests/unit/client/reducers/groupNested.tests.js
+++ b/tests/unit/client/reducers/groupNested.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { groupNested } from '../../../client/reducers/groupNested';
-import * as constants from '../../../client/constants';
+import { groupNested } from '../../../../client/reducers/groupNested';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   error: null,

--- a/tests/unit/client/reducers/groupPicker.tests.js
+++ b/tests/unit/client/reducers/groupPicker.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { groupPicker } from '../../../client/reducers/groupPicker';
-import * as constants from '../../../client/constants';
+import { groupPicker } from '../../../../client/reducers/groupPicker';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   error: null,

--- a/tests/unit/client/reducers/groupRoles.tests.js
+++ b/tests/unit/client/reducers/groupRoles.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { groupRoles } from '../../../client/reducers/groupRoles';
-import * as constants from '../../../client/constants';
+import { groupRoles } from '../../../../client/reducers/groupRoles';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/groups.tests.js
+++ b/tests/unit/client/reducers/groups.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { groups } from '../../../client/reducers/groups';
-import * as constants from '../../../client/constants';
+import { groups } from '../../../../client/reducers/groups';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/importExport.tests.js
+++ b/tests/unit/client/reducers/importExport.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { importExport } from '../../../client/reducers/importExport';
-import * as constants from '../../../client/constants';
+import { importExport } from '../../../../client/reducers/importExport';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/permission.tests.js
+++ b/tests/unit/client/reducers/permission.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { permission } from '../../../client/reducers/permission';
-import * as constants from '../../../client/constants';
+import { permission } from '../../../../client/reducers/permission';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/permissions.tests.js
+++ b/tests/unit/client/reducers/permissions.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { permissions } from '../../../client/reducers/permissions';
-import * as constants from '../../../client/constants';
+import { permissions } from '../../../../client/reducers/permissions';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/role.tests.js
+++ b/tests/unit/client/reducers/role.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { role } from '../../../client/reducers/role';
-import * as constants from '../../../client/constants';
+import { role } from '../../../../client/reducers/role';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/roles.tests.js
+++ b/tests/unit/client/reducers/roles.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { roles } from '../../../client/reducers/roles';
-import * as constants from '../../../client/constants';
+import { roles } from '../../../../client/reducers/roles';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/ruleStatus.tests.js
+++ b/tests/unit/client/reducers/ruleStatus.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { ruleStatus } from '../../../client/reducers/ruleStatus';
-import * as constants from '../../../client/constants';
+import { ruleStatus } from '../../../../client/reducers/ruleStatus';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/user.tests.js
+++ b/tests/unit/client/reducers/user.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { user } from '../../../client/reducers/user';
-import * as constants from '../../../client/constants';
+import { user } from '../../../../client/reducers/user';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/userPicker.tests.js
+++ b/tests/unit/client/reducers/userPicker.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { userPicker } from '../../../client/reducers/userPicker';
-import * as constants from '../../../client/constants';
+import { userPicker } from '../../../../client/reducers/userPicker';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   error: null,

--- a/tests/unit/client/reducers/userRoles.tests.js
+++ b/tests/unit/client/reducers/userRoles.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { userRoles } from '../../../client/reducers/userRoles';
-import * as constants from '../../../client/constants';
+import { userRoles } from '../../../../client/reducers/userRoles';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/client/reducers/users.tests.js
+++ b/tests/unit/client/reducers/users.tests.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
-import { users } from '../../../client/reducers/users';
-import * as constants from '../../../client/constants';
+import { users } from '../../../../client/reducers/users';
+import * as constants from '../../../../client/constants';
 
 const initialState = {
   loading: false,

--- a/tests/unit/server/lib/queries.tests.js
+++ b/tests/unit/server/lib/queries.tests.js
@@ -2,7 +2,7 @@ import uuid from 'node-uuid';
 import Promise from 'bluebird';
 import { expect } from 'chai';
 
-import { getUserGroups, getDynamicUserGroups, getGroupExpanded } from '../../../server/lib/queries';
+import { getUserGroups, getDynamicUserGroups, getGroupExpanded } from '../../../../server/lib/queries';
 
 const mockDatabase = (groups, roles, permissions) => ({
   hash: uuid.v4(),


### PR DESCRIPTION
Two endpoints added:
 - DELETE api/users/[user_id] - removes userId from all groups and roles
 - PATCH api/users/[old_user_id]/[new_user_id] - replaces userId in all groups and roles