### PR TITLE
Changes to avoid Blocking event loop

### DIFF
--- a/server/api/policy/routes/post_user.js
+++ b/server/api/policy/routes/post_user.js
@@ -21,10 +21,7 @@ module.exports = (server) => ({
         clientId: Joi.string().required()
       },
       payload: schema
-    },
-    pre: [
-      server.handlers.managementClient
-    ]
+    }
   },
   handler: (req, reply) => {
     const { userId, clientId } = req.params;

--- a/webtask.js
+++ b/webtask.js
@@ -1,17 +1,30 @@
 const tools = require('auth0-extension-hapi-tools');
-
-const hapiApp = require('./server/init');
 const config = require('./server/lib/config');
 const logger = require('./server/lib/logger');
 
-const createServer = tools.createServer((wtConfig, wtStorage) => {
+const factory = (wtConfig, wtStorage) => {
   logger.info('Starting Authorization Extension - Version:', process.env.CLIENT_VERSION);
   logger.info(' > WT_URL:', wtConfig('WT_URL'));
   logger.info(' > PUBLIC_WT_URL:', config('PUBLIC_WT_URL'));
-  return hapiApp(wtConfig, wtStorage);
-});
+  // Require in place to load the dependency only when needed
+  // and avoid Blocked event loop errors
+  return require('./server/init')(wtConfig, wtStorage);
+};
+
+  // Loading all modules at the beginning takes too much time
+  // that causes "Blocked event loop errors"
+  // This function is a helper to avoid this type of errors
+var createServer = (context, req, res) => {
+  // To avoid the  "Blocked event loop" error we delay loading the application module
+  setImmediate(() => {
+    config.setValue('PUBLIC_WT_URL', tools.urlHelpers.getWebtaskUrl(req));
+    // After the application has been initialized we remove the 
+    // artificial delay in processing
+    createServer = tools.createServer(factory);
+    createServer(context, req, res);
+  });
+};
 
 module.exports = (context, req, res) => {
-  config.setValue('PUBLIC_WT_URL', tools.urlHelpers.getWebtaskUrl(req));
   createServer(context, req, res);
 };


### PR DESCRIPTION
Currently the extension is resulting in _Blocked Event Loop_ errors for some customers. After reviewing we foun that one of the causes is the time it takes to load all modules during the first setup. This change moves the application initialization to a next poll to minimize the errors.