### PR TITLE
Add basic mongodb storage support

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "async": "2.1.2",
     "auth0": "2.8.0",
     "auth0-extension-hapi-tools": "1.2.0",
+    "auth0-extension-mongo-tools": "^0.1.0",
     "auth0-extension-s3-tools": "1.1.1",
     "auth0-extension-tools": "1.2.1",
     "auth0-extension-ui": "1.0.1",

--- a/server/lib/storage/providers.js
+++ b/server/lib/storage/providers.js
@@ -1,12 +1,34 @@
 import path from 'path';
 import { S3StorageContext } from 'auth0-extension-s3-tools';
 import { FileStorageContext, WebtaskStorageContext, BlobRecordProvider } from 'auth0-extension-tools';
+import { MongoRecordProvider } from 'auth0-extension-mongo-tools';
 
 import config from '../config';
 import logger from '../logger';
 
 export function createProvider(storageContext) {
   switch (config('STORAGE_TYPE')) {
+    case 'mongodb': {
+      logger.info('Initializing the MongoDB Storage Provider.');
+      const mongoProvider = new MongoRecordProvider(config('MONGODB_URL'));
+      mongoProvider.storageContext = {
+        read: async () => {
+          const groups = mongoProvider.getAll('groups');
+          const roles = mongoProvider.getAll('roles');
+          const permissions = mongoProvider.getAll('permissions');
+
+          const resolved = await Promise.all([groups, roles, permissions]);
+
+          return {
+            groups: resolved[0],
+            roles: resolved[1],
+            permissions: resolved[2]
+          };
+        }
+      };
+
+      return mongoProvider;
+    }
     case 's3': {
       logger.info('Initializing the S3 Storage Context.');
 

--- a/webtask.json
+++ b/webtask.json
@@ -35,6 +35,10 @@
         {
           "value": "s3",
           "text": "Amazon S3"
+        },
+        {
+          "value": "mongodb",
+          "text": "MongoDB"
         }
       ]
     },
@@ -69,6 +73,14 @@
       "example": "r3UOMBA......................",
       "visibleIf": {
         "STORAGE_TYPE": "s3"
+      }
+    },
+    "MONGODB_URL": {
+      "description": "Your MongoDB url",
+      "required": true,
+      "example": "mongodb://some.mongodb.host:27017/database-name",
+      "visibleIf": {
+        "STORAGE_TYPE": "mongodb"
       }
     }
   }


### PR DESCRIPTION
Add basic mongodb storage support. There is still a lot of room for optimising requests, so the storage provider handles filtering, instead of it being done by the extension in memory.