### PR TITLE
Use a dedicated `nonceKey`

### DIFF
--- a/server/plugins/auth.js
+++ b/server/plugins/auth.js
@@ -116,6 +116,7 @@ module.exports.register = (server, options, next) => {
     register: tools.plugins.dashboardAdminSession,
     options: {
       stateKey: 'authz-state',
+      nonceKey: 'authz-nonce',
       sessionStorageKey: 'authz:apiToken',
       rta: config('AUTH0_RTA').replace('https://', ''),
       domain: config('AUTH0_DOMAIN'),


### PR DESCRIPTION
## ✏️ Changes
  
Use "authz-nonce" as a dedicated `nonceKey` to avoid nonce cookie collisions from other extensions.

While it doesn't hurt anything, this fix is a bandaid. an additional solution is forthcoming in `auth0-extension-hapi-tools`.
  
## 📷 Screenshots

New nonce key:
![image](https://user-images.githubusercontent.com/947526/47100580-d846fb00-d205-11e8-9284-b29f9160dc0a.png)

## 🔗 References
  
- [Zendesk](https://auth0.zendesk.com/agent/filters/54738528)
  
## 🎯 Testing
  
1. log into another extension, such as SSO dashboard (though others may work)
2. then log into Authz Extension
3. ensure no `nonce mismatch`
   
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time - no module dependency updates
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will perform a smoke test
  
## 🔥 Rollback
    
We will rollback if users are unable to login to the Authorization Extension
  
### 📄 Procedure
  
Restore from CDN
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
