### PR TITLE
add groups/roles to user by id or name

### DIFF
--- a/server/api/users-groups/routes/patch_user_add_to_group.js
+++ b/server/api/users-groups/routes/patch_user_add_to_group.js
@@ -1,5 +1,6 @@
 import Promise from 'bluebird';
 import Joi from 'joi';
+import _ from 'lodash';
 
 module.exports = () => ({
   method: 'PATCH',
@@ -15,23 +16,27 @@ module.exports = () => ({
       params: {
         id: Joi.string().required()
       },
-      payload: Joi.array().items(Joi.string().guid()).required().min(1)
+      payload: Joi.array().items(Joi.string()).required().min(1)
     }
   },
   handler: (req, reply) => {
     const groupIds = req.payload;
+    const pattern = /^(\{{0,1}([0-9a-fA-F]){8}-?([0-9a-fA-F]){4}-?([0-9a-fA-F]){4}-?([0-9a-fA-F]){4}-?([0-9a-fA-F]){12}\}{0,1})$/;
+    const searchBy = pattern.test(groupIds[0]) ? '_id' : 'name';
 
-    return Promise.each(groupIds, id => req.storage.getGroup(id)
-      .then(group => {
-        if (!group.members) {
-          group.members = []; // eslint-disable-line no-param-reassign
-        }
-        if (group.members.indexOf(req.params.id) === -1) {
-          group.members.push(req.params.id);
-        }
+    req.storage.getGroups()
+      .then((groups) => _.filter(groups, (group) => _.includes(groupIds, group[searchBy])))
+      .then((filtered) =>
+        Promise.each(filtered, (group) => {
+          if (!group.members) {
+            group.members = []; // eslint-disable-line no-param-reassign
+          }
+          if (group.members.indexOf(req.params.id) === -1) {
+            group.members.push(req.params.id);
+          }
 
-        return req.storage.updateGroup(id, group);
-      }))
+          return req.storage.updateGroup(group._id, group);
+        }))
       .then(() => reply().code(204))
       .catch(err => reply.error(err));
   }

--- a/server/api/users-roles/routes/patch_user_add_to_roles.js
+++ b/server/api/users-roles/routes/patch_user_add_to_roles.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Promise from 'bluebird';
 import Joi from 'joi';
 
@@ -15,23 +16,26 @@ module.exports = () => ({
       params: {
         id: Joi.string().required()
       },
-      payload: Joi.array().items(Joi.string().guid()).required().min(1)
+      payload: Joi.array().items(Joi.string()).required().min(1)
     }
   },
   handler: (req, reply) => {
     const roleIds = req.payload;
+    const pattern = /^(\{{0,1}([0-9a-fA-F]){8}-?([0-9a-fA-F]){4}-?([0-9a-fA-F]){4}-?([0-9a-fA-F]){4}-?([0-9a-fA-F]){12}\}{0,1})$/;
+    const searchBy = pattern.test(roleIds[0]) ? '_id' : 'name';
+    req.storage.getRoles()
+      .then((roles) => _.filter(roles, (role) => _.includes(roleIds, role[searchBy])))
+      .then((filtered) =>
+        Promise.each(filtered, (role) => {
+          if (!role.users) {
+            role.users = []; // eslint-disable-line no-param-reassign
+          }
+          if (role.users.indexOf(req.params.id) === -1) {
+            role.users.push(req.params.id);
+          }
 
-    return Promise.each(roleIds, id => req.storage.getRole(id)
-      .then(role => {
-        if (!role.users) {
-          role.users = []; // eslint-disable-line no-param-reassign
-        }
-        if (role.users.indexOf(req.params.id) === -1) {
-          role.users.push(req.params.id);
-        }
-
-        return req.storage.updateRole(id, role);
-      }))
+          return req.storage.updateRole(role._id, role);
+        }))
       .then(() => reply().code(204))
       .catch(err => reply.error(err));
   }

--- a/tests/unit/server/users-groups-route.tests.js
+++ b/tests/unit/server/users-groups-route.tests.js
@@ -178,6 +178,11 @@ describe('users-groups-route', () => {
   });
 
   describe('#patch', () => {
+    beforeEach((done) => {
+      group.members = null;
+      done();
+    });
+
     it('should return 403 if scope is missing (update groups)', (cb) => {
       const token = getToken();
       const options = {
@@ -203,6 +208,25 @@ describe('users-groups-route', () => {
           Authorization: `Bearer ${token}`
         },
         payload: [ group._id ]
+      };
+
+      server.inject(options, (response) => {
+        expect(response.statusCode).to.equal(204);
+        expect(group.id).to.be.equal(group._id);
+        expect(group.members[0]).to.be.equal('userId');
+        cb();
+      });
+    });
+
+    it('should add user to groups by name', (cb) => {
+      const token = getToken('update:groups');
+      const options = {
+        method: 'PATCH',
+        url: '/api/users/userId/groups',
+        headers: {
+          Authorization: `Bearer ${token}`
+        },
+        payload: [ group.name ]
       };
 
       server.inject(options, (response) => {

--- a/tests/unit/server/users-roles-route.tests.js
+++ b/tests/unit/server/users-roles-route.tests.js
@@ -142,6 +142,11 @@ describe('users-groups-route', () => {
   });
 
   describe('#patch', () => {
+    beforeEach((done) => {
+      groupRole.users = null;
+      done();
+    });
+
     it('should return 403 if scope is missing (update roles)', (cb) => {
       const token = getToken();
       const options = {
@@ -167,6 +172,25 @@ describe('users-groups-route', () => {
           Authorization: `Bearer ${token}`
         },
         payload: [ groupRole._id ]
+      };
+
+      server.inject(options, (response) => {
+        expect(response.statusCode).to.equal(204);
+        expect(groupRole.id).to.be.equal(groupRole._id);
+        expect(groupRole.users[0]).to.be.equal('userId');
+        cb();
+      });
+    });
+
+    it('should add user to role by role name', (cb) => {
+      const token = getToken('update:roles');
+      const options = {
+        method: 'PATCH',
+        url: '/api/users/userId/roles',
+        headers: {
+          Authorization: `Bearer ${token}`
+        },
+        payload: [ groupRole.name ]
       };
 
       server.inject(options, (response) => {


### PR DESCRIPTION
## ✏️ Changes
  Fixes #233 
PATCH `/api/users/{user_id}/groups` and `/api/users/{user_id}/roles` routes now can accept list of names (groups of roles).

## 🔗 References
  GH Issue: #233
  
## 🎯 Testing
✅ This change has been tested locally
🚫 This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  