### PR TITLE
[CF-444] feat: perform paginated calls to fetch all

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authz-extension",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Auth0 Authorization Extension",
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authz-extension",
-  "version": "2.8.2",
+  "version": "2.8.1",
   "description": "Auth0 Authorization Extension",
   "engines": {
     "node": ">=12"

--- a/server/api/configuration/routes/get_configuration_status.js
+++ b/server/api/configuration/routes/get_configuration_status.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import multipartRequest from '../../../lib/multipartRequest';
 
 module.exports = (server) => ({
   method: 'GET',
@@ -13,7 +14,7 @@ module.exports = (server) => ({
     ]
   },
   handler: (req, reply) =>
-    req.pre.auth0.rules.getAll()
+      multipartRequest(req.pre.auth0, 'rules', { fields: 'name,enabled' })
       .then(rules => {
         const rule = _.find(rules, { name: 'auth0-authorization-extension' });
         return {

--- a/server/api/configuration/routes/patch_configuration.js
+++ b/server/api/configuration/routes/patch_configuration.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 
 import schema from '../schemas/configuration';
 import compileRule from '../../../lib/compileRule';
+import multipartRequest from '../../../lib/multipartRequest';
 
 module.exports = (server) => ({
   method: 'PATCH',
@@ -26,7 +27,7 @@ module.exports = (server) => ({
 
     compileRule(req.storage, req.pre.auth0, config, req.auth.credentials.email || 'unknown')
       .then((script) => {
-        req.pre.auth0.rules.getAll()
+        multipartRequest(req.pre.auth0, 'rules', { fields: 'name,id' })
           .then(rules => {
             const payload = {
               name: 'auth0-authorization-extension',

--- a/server/api/extension-hooks/routes/delete_uninstall.js
+++ b/server/api/extension-hooks/routes/delete_uninstall.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import config from '../../../lib/config';
 import { deleteApi } from '../../../lib/apiaccess';
+import multipartRequest from '../../../lib/multipartRequest';
 
 module.exports = (server) => ({
   method: 'DELETE',
@@ -13,9 +14,7 @@ module.exports = (server) => ({
     ]
   },
   handler: (req, reply) => {
-    req.pre.auth0
-      .rules
-      .getAll()
+    multipartRequest(req.pre.auth0, 'rules', { fields: 'name,id' })
       .then(rules => {
         const rule = _.find(rules, { name: 'auth0-authorization-extension' });
         if (rule) {

--- a/server/lib/multipartRequest.js
+++ b/server/lib/multipartRequest.js
@@ -8,7 +8,7 @@ module.exports = function(
   entity,
   opts = {},
   perPage = 100,
-  concurrency = 5
+  concurrency = 3
 ) {
   if (client === null || client === undefined) {
     throw new ArgumentError('Must provide a auth0 client object.');

--- a/server/lib/queries.js
+++ b/server/lib/queries.js
@@ -3,6 +3,7 @@ import nconf from 'nconf';
 import Promise from 'bluebird';
 import memoizer from 'lru-memoizer';
 import apiCall from './apiCall';
+import multipartRequest from './multipartRequest';
 
 const avoidBlock = (action) => (...args) =>
   new Promise((resolve, reject) => {
@@ -26,7 +27,7 @@ const compact = (entity) => ({
  */
 export const getConnectionsCached = memoizer({
   load: (auth0, callback) => {
-    apiCall(auth0, auth0.connections.getAll, [ { fields: 'id,name,strategy' } ])
+    multipartRequest(auth0, 'connections', { fields: 'id,name,strategy' })
       .then((connections) =>
         _.chain(connections)
           .sortBy((conn) => conn.name.toLowerCase())


### PR DESCRIPTION
## ✏️ Changes
  
Use pagination to fetch all rules and connections. The PR uses the `multipartRequest` helper that was already available.
    
## 🎯 Testing
  
✅ This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
✅ This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
 