### PR TITLE
Change unpaginated request to get by id request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.11.0] - 2021-01-25
+
+- Fix local development
+- Replaced unpaginated query to resource server endpoint with get by id
+
 ## [2.10.0] - 2020-08-28
 
 - User search engine configuration added.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authz-extension",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authz-extension",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Auth0 Authorization Extension",
   "engines": {
     "node": ">=12"

--- a/server/lib/apiaccess.js
+++ b/server/lib/apiaccess.js
@@ -63,7 +63,7 @@ const makeRequest = (req, path, method, payload) =>
   );
 
 export const getApi = (req) =>
-  makeRequest(req, `resource-servers/${apiIdentifier}`, 'GET').catch(e => { return {}; });
+  makeRequest(req, `resource-servers/${apiIdentifier}`, 'GET').catch(() => ({}));
 
 export const createApi = (req, lifeTime) => {
   const payload = {

--- a/server/lib/apiaccess.js
+++ b/server/lib/apiaccess.js
@@ -63,10 +63,7 @@ const makeRequest = (req, path, method, payload) =>
   );
 
 export const getApi = (req) =>
-  makeRequest(req, 'resource-servers', 'GET').then((apis) => {
-    const api = apis.filter((item) => item.identifier === apiIdentifier);
-    return api[0] || {};
-  });
+  makeRequest(req, `resource-servers/${apiIdentifier}`, 'GET').catch(e => { return {}; });
 
 export const createApi = (req, lifeTime) => {
   const payload = {

--- a/tests/unit/server/configuration-route.tests.js
+++ b/tests/unit/server/configuration-route.tests.js
@@ -9,9 +9,9 @@ describe('configuration-route', () => {
   const rules = [
     { name: 'auth0-authorization-extension', enabled: true, id: 'ruleId' }
   ];
-  const resourceServers = [
+  const resourceServer =
     { identifier: 'urn:auth0-authz-api', token_lifetime: 10, id: 'rsid' }
-  ];
+  ;
   let storageData = null;
 
   before((done) => {
@@ -148,7 +148,7 @@ describe('configuration-route', () => {
 
     it('should return resource-server data', (cb) => {
       const token = getToken('read:resource-server');
-      auth0.get('/api/v2/resource-servers', resourceServers);
+      auth0.get('/api/v2/resource-servers/urn:auth0-authz-api', resourceServer);
       const options = {
         method: 'GET',
         url: '/api/configuration/resource-server',
@@ -160,6 +160,23 @@ describe('configuration-route', () => {
       server.inject(options, (response) => {
         expect(response.result.apiAccess).to.equal(true);
         expect(response.result.token_lifetime).to.equal(10);
+        cb();
+      });
+    });
+
+    it('should return resource-server empty when resource server not found', (cb) => {
+      const token = getToken('read:resource-server');
+      auth0.get('/api/v2/resource-servers/urn:auth0-authz-api', {});
+      const options = {
+        method: 'GET',
+        url: '/api/configuration/resource-server',
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      };
+
+      server.inject(options, (response) => {
+        expect(response.result.apiAccess).to.equal(false);
         cb();
       });
     });
@@ -243,8 +260,8 @@ describe('configuration-route', () => {
 
     it('should update resource-server', (cb) => {
       const token = getToken('update:resource-server');
-      auth0.get('/api/v2/resource-servers', resourceServers);
-      auth0.get('/api/v2/resource-servers', resourceServers);
+      auth0.get('/api/v2/resource-servers/urn:auth0-authz-api', resourceServer);
+      auth0.get('/api/v2/resource-servers/urn:auth0-authz-api', resourceServer);
       auth0.patch('/api/v2/resource-servers/rsid');
       const options = {
         method: 'PATCH',
@@ -365,7 +382,7 @@ describe('configuration-route', () => {
 
     it('should delete resource-server', (cb) => {
       const token = getToken('delete:resource-server');
-      auth0.get('/api/v2/resource-servers', resourceServers);
+      auth0.get('/api/v2/resource-servers/urn:auth0-authz-api', resourceServer);
       auth0.delete('/api/v2/resource-servers/rsid');
       const options = {
         method: 'DELETE',

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Authorization",
   "name": "auth0-authz",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to manage group memberships for their users.",
   "type": "application",


### PR DESCRIPTION
## ✏️ Changes
  
The API section was searching the API but getting all APIs and filtering by identifier. We changed the logic to search that identifier from the API. If the request fails, then we assume it does not exist.

  
## 📷 Screenshots
 
When resource server doesn't exist, this section is rendered like this
![image](https://user-images.githubusercontent.com/1765468/105697331-b8ceca80-5f04-11eb-9105-c5d0a1a090b5.png)

When resource server exists, the section is rendered like this:
![image](https://user-images.githubusercontent.com/1765468/105697950-870a3380-5f05-11eb-8d95-3ef9adf84f6e.png)

  
## 🔗 References
  
https://auth0.com/docs/product-lifecycle/deprecations-and-migrations/migrate-to-paginated-queries
  
## 🎯 Testing
  
✅ This change has been tested in a Webtask
✅ This change has unit test coverage
✅ This change has integration test coverage
🚫 This change has been tested for performance
  

