### PR TITLE
fix: [SEC-2370] upgrade async from 2.6.3 to 2.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@hapi/good-console": "9.0.1",
         "@hapi/hapi": "21.3.3",
         "@hapi/inert": "7.1.0",
-        "async": "2.6.3",
+        "async": "2.6.4",
         "auth0": "3.5.0",
         "auth0-extension-tools": "1.5.2",
         "auth0-extension-ui": "1.1.7",
@@ -5972,10 +5972,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "license": "MIT",
+      "version": "2.6.4",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -11763,16 +11762,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/caporal/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/caporal/node_modules/bluebird": {
@@ -25557,16 +25546,6 @@
       },
       "engines": {
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/portfinder/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/portfinder/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "@hapi/good@9.0.1",
       "@hapi/good-console@9.0.1",
       "@hapi/hapi@21.3.3",
-      "async@2.6.3",
+      "async@2.6.4",
       "auth0-extension-tools@1.5.2",
       "axios@1.6.5",
       "blipp@4.0.2",
@@ -64,7 +64,7 @@
     "@hapi/good-console": "9.0.1",
     "@hapi/hapi": "21.3.3",
     "@hapi/inert": "7.1.0",
-    "async": "2.6.3",
+    "async": "2.6.4",
     "auth0": "3.5.0",
     "auth0-extension-tools": "1.5.2",
     "auth0-extension-ui": "1.1.7",
@@ -183,7 +183,9 @@
     "webtask-bundle": "3.0.1"
   },
   "overrides": {
-    "auth0-extension-tools": "1.5.2",
+    "auth0-extension-tools": {
+      "async": "2.6.4"
+    },
     "react-router": "3.0.2",
     "@hapi/hoek": "^9.3.0",
     "@hapi/validate": "1.1.3",


### PR DESCRIPTION
## ✏️ Changes

Upgrade async from 2.6.3 to 2.6.4. 
  
## 🔗 References

https://auth0team.atlassian.net/browse/IDS-5543  
  
## 🎯 Testing
  
✅ This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
✅ This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
Authz-extension `2.3.0` is not officially released yet. The release will be done when extensions.json in the webtask will be 
  
## 🎡 Rollout

1. This PR will be merged.
1. We will add `async@2.6.4` to webtask. 
2. We will release node 22 extension with the fix from this PR.
  
## 🔥 Rollback

We will rollback this extension version to the previous one, if this change breaks anything.
  
### 📄 Procedure

We will rollback extension to the previous one.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
