### PR TITLE
fix: [IDS-5574] Fix multipart request + add unit tests

### DIFF
--- a/server/lib/multipartRequest.js
+++ b/server/lib/multipartRequest.js
@@ -31,7 +31,7 @@ export default async function(
     ]);
 
     total = response.total || 0;
-    pageCount = Math.ceil(total / perPage);
+    pageCount = Math.ceil(total / perPage) - 1;
     const data = response[entity] || response || [];
     data.forEach((item) => result.push(item));
     return null;
@@ -55,9 +55,9 @@ export default async function(
       pages.push(i);
     }
 
-    const getAllResult = await promiseMap(pages, getPage, { concurrency });
+    await promiseMap(pages, getPage, { concurrency });
 
-    return getAllResult;
+    return result;
   };
 
   return getAll();

--- a/server/lib/multipartRequest.js
+++ b/server/lib/multipartRequest.js
@@ -31,7 +31,7 @@ export default async function(
     ]);
 
     total = response.total || 0;
-    pageCount = Math.ceil(total / perPage) - 1;
+    pageCount = Math.ceil(total / perPage);
     const data = response[entity] || response || [];
     data.forEach((item) => result.push(item));
     return null;
@@ -51,7 +51,7 @@ export default async function(
     }
 
     const pages = [];
-    for (let i = 1; i <= pageCount; i++) {
+    for (let i = 1; i < pageCount; i++) {
       pages.push(i);
     }
 

--- a/tests/unit/mocks/auth0.js
+++ b/tests/unit/mocks/auth0.js
@@ -1,9 +1,17 @@
 import nock from 'nock';
 
-module.exports.get = (route, data, code = 200, times = 1) =>
+module.exports.get = (route, data, code = 200, times = 1, query = {}) =>
    nock('https://foo.auth0.local')
     .get(route)
-    .query(() => true)
+    .query((actualQuery) => {
+      // don't care about the query -> accept any
+      if (Object.keys(query).length === 0) {
+        return true;
+      }
+
+      // do care about the query -> check if it matches
+      return Object.keys(query).every((key) => actualQuery[key] === query[key]);
+    })
     .times(times)
     .reply(code, data);
 

--- a/tests/unit/server/multipartRequest.tests.js
+++ b/tests/unit/server/multipartRequest.tests.js
@@ -1,0 +1,78 @@
+
+import _ from 'lodash';
+import { expect } from 'chai';
+import { ManagementClient } from 'auth0';
+
+import * as auth0Nocks from '../mocks/auth0';
+import { getToken } from '../mocks/tokens';
+import multipartRequest from '../../../server/lib/multipartRequest';
+import config from '../../../server/lib/config';
+
+const buildClients = (count) => Array.from({ length: count }, (_value, index) => ({
+  name: `app_${index}`,
+  global: false,
+  app_type: 'spa',
+  client_id: `client_id_${index}`
+}));
+
+describe('multipartRequest', () => {
+  let auth0Client;
+
+  beforeEach(() => {
+    const token = getToken('read:applications');
+    auth0Client = new ManagementClient({ domain: config('AUTH0_DOMAIN'), token });
+  });
+
+  it('should fetch 10 clients in 1 request', async () => {
+    const applications = buildClients(10);
+
+    auth0Nocks.get('/api/v2/clients', applications, 200, 1, { include_totals: 'true', per_page: '100', page: '0' });
+
+    const result = await multipartRequest(auth0Client, 'clients', {}, 100);
+
+    expect(result).to.be.an('array');
+    expect(result).to.have.lengthOf(10);
+    expect(result).to.deep.equal(applications);
+  });
+
+  it('should fetch 150 clients in 2 requests', async () => {
+    const applications = buildClients(150);
+    const applicationsChunked = _.chunk(applications, 100);
+
+    // first request contains totals
+    auth0Nocks.get('/api/v2/clients',
+      { clients: applicationsChunked[0], total: 150 },
+      200,
+      1,
+      { include_totals: 'true', per_page: '100', page: '0' });
+    auth0Nocks.get('/api/v2/clients', applicationsChunked[1], 200, 1, { page: '1' });
+
+    const result = await multipartRequest(auth0Client, 'clients', {}, 100);
+
+    expect(result).to.be.an('array');
+    expect(result).to.have.lengthOf(150);
+    expect(result).to.deep.equal(applications);
+  });
+
+  it('should fetch 500 clients in 5 requests', async () => {
+    const applications = buildClients(500);
+    const applicationsChunked = _.chunk(applications, 100);
+
+    // first request contains totals
+    auth0Nocks.get('/api/v2/clients',
+      { clients: applicationsChunked[0], total: 500 },
+      200,
+      1,
+      { include_totals: 'true', per_page: '100', page: '0' });
+    auth0Nocks.get('/api/v2/clients', applicationsChunked[1], 200, 1, { page: '1' });
+    auth0Nocks.get('/api/v2/clients', applicationsChunked[2], 200, 1, { page: '2' });
+    auth0Nocks.get('/api/v2/clients', applicationsChunked[3], 200, 1, { page: '3' });
+    auth0Nocks.get('/api/v2/clients', applicationsChunked[4], 200, 1, { page: '4' });
+
+    const result = await multipartRequest(auth0Client, 'clients', {}, 100);
+
+    expect(result).to.be.an('array');
+    expect(result).to.have.lengthOf(500);
+    expect(result).to.deep.equal(applications);
+  });
+});


### PR DESCRIPTION
## ✏️ Changes
  
- `multipartRequest` makes multiple request to paginate through entities from api2, with a page size of 100. However, when required to make more than one request, it was failing to return correctly.
- This PR fixes `multipartRequest` so that it correctly returns an aggregated array of data from multiple requests, and adds unit tests to prevent further regressions.
    
## 🔗 References
  
- https://auth0team.atlassian.net/browse/IDS-5574
  
## 🎯 Testing
   
🚫 This change has been tested in a Webtask --> this should be in webtask before the node22 roll out.
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
🚫 This change will be released with the node 22 update
    
## 🎡 Rollout
  
In order to verify that the deployment was successful we will test the node22 version of the extension in a prod tenant before and after release
  
## 🔥 Rollback
  
We will rollback if there are issues affecting core auth flows, or fix issues affecting the extension UI
  
### 📄 Procedure
  
- to "rollback" we would upload a previous build of the extension as the current version
