### PR TITLE
fix: upgrade formidable to 2.1.3 to resolve CVE-2025-46653

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -985,7 +985,6 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -5275,7 +5274,6 @@
       "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8587,7 +8585,6 @@
       "integrity": "sha512-td7fYwgLSrky3fI1EuU5cneU4+pbH6GgOfuKNS1tNPcfdGinGELAqsb/BP4nnvZyKSG2i/xFGU7+n2PvZA8HJQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-module-context": "1.9.0",
@@ -9343,6 +9340,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/auth0-js/node_modules/formidable": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.3.tgz",
+      "integrity": "sha512-vDI5JjeALeGXpyL8v71ZG2VgHY5zD6qg1IvypU7aJCYvREZyhawrYJxMdsWO+m5DIGLiMiDH71yEN8RO4wQAMQ==",
+      "deprecated": "ATTENTION: please upgrade to v3! The v1 and v2 versions are pretty old and deprecated",
+      "dev": true,
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/auth0-js/node_modules/readable-stream": {
@@ -10728,7 +10741,6 @@
       "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/@babel/runtime-corejs3/-/runtime-corejs3-7.26.0.tgz",
       "integrity": "sha512-YXHu5lN8kJCb1LOb9PgV6pvak43X2h4HvRApcN5SdWeaItQOzfn1hgP6jasD6KWQyJDBxrVmA9o9OivlnNJK/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
@@ -11429,7 +11441,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -13274,7 +13285,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -15086,7 +15096,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "babel-code-frame": "^6.16.0",
         "chalk": "^1.1.3",
@@ -15239,7 +15248,6 @@
       "integrity": "sha512-69zk4fLTFIV4nUaZQfdXyDjSIuymcc4y7ZMywQSnmySpy6MlvDCduug7+G0e6FJMOvEvNC/1N5xDbZvZQphm1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtin-modules": "^1.1.1",
         "contains-path": "^0.1.0",
@@ -15291,7 +15299,6 @@
       "integrity": "sha512-OS+axp7UzxE7fmiTHiv9GEavlCfYFIXLQvyEZLMOAJB1/wALDVfWi2KPlj9TKbP97cof/7ZSVwaG6lpUKq8Tog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "damerau-levenshtein": "^1.0.0",
         "jsx-ast-utils": "^1.0.0",
@@ -15310,7 +15317,6 @@
       "integrity": "sha512-vFfMSxJynKlgOhIVjhlZyibVUg442Aiv3482XPkgdYV90T8nD2QvxGXILZGwZHYMQ/l+A/De14O9D0qjDelSrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array.prototype.find": "^2.0.1",
         "doctrine": "^1.2.2",
@@ -16569,21 +16575,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
-      "license": "MIT",
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/forwarded/-/forwarded-0.2.0.tgz",
@@ -17606,15 +17597,6 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/history": {
@@ -22066,7 +22048,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -27219,7 +27200,6 @@
       "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
       "deprecated": "false",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "create-react-class": "^15.6.0",
         "fbjs": "^0.8.9",
@@ -27306,7 +27286,6 @@
       "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha512-qxrSETbovswZ0xXs1o5+1o9NfNYbLnQWUqhef36tDWb+tGrbsHjEel5DZuncWMbO0rWd5e4AvCoJBOWm3x6p3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fbjs": "^0.8.9",
         "loose-envify": "^1.1.0",
@@ -27450,7 +27429,6 @@
       "integrity": "sha512-XNguUSFvjBcti5d1vWvLURETiSLPZW1+ugveIa38SgD3aczVqwENNjjC2jtBRMBOziJZDsnmneCLB+I+pkLNTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hoist-non-react-statics": "^1.0.3",
         "invariant": "^2.0.0",
@@ -27468,7 +27446,6 @@
       "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/react-router/-/react-router-3.0.2.tgz",
       "integrity": "sha512-RmdTKs9p6uZRoPEIglKsf8Y6LFbW2vLAgN8hmqlxmBqNx0kQUh2/ufBSHLbanHicwGeHZusxzxECLfdBjh2Lkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "history": "^3.0.0",
         "hoist-non-react-statics": "^1.2.0",
@@ -27509,7 +27486,6 @@
       "integrity": "sha512-jflbohN8XxJJ91ItKcAFy7B3GE9aLdyifV6w4qcsRcLpWTmVEAZ33h5MmfHPKhGli6FoPZM5VC1/Xnu1TPCqSw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "fbjs": "^0.8.9",
         "object-assign": "^4.1.0"
@@ -27825,7 +27801,6 @@
       "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.2.1",
         "lodash-es": "^4.2.1",
@@ -27840,7 +27815,6 @@
       "deprecated": "Package moved to @redux-devtools/core.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.2.0",
         "prop-types": "^15.5.7",
@@ -28591,6 +28565,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/rest-facade/node_modules/formidable": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.3.tgz",
+      "integrity": "sha512-vDI5JjeALeGXpyL8v71ZG2VgHY5zD6qg1IvypU7aJCYvREZyhawrYJxMdsWO+m5DIGLiMiDH71yEN8RO4wQAMQ==",
+      "deprecated": "ATTENTION: please upgrade to v3! The v1 and v2 versions are pretty old and deprecated",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/rest-facade/node_modules/readable-stream": {
@@ -30600,7 +30589,6 @@
       "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/stylus/-/stylus-0.54.8.tgz",
       "integrity": "sha512-vr54Or4BZ7pJafo2mpf0ZcwA74rpuYCZbxrHBsH8kbcXOwSfvBFwsRfpGO5OD5fhG5HDCFW737PKaawI7OqEAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-parse": "~2.0.0",
         "debug": "~3.1.0",
@@ -30881,7 +30869,6 @@
       "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "co": "^4.6.0",
         "json-stable-stringify": "^1.0.1"
@@ -31240,7 +31227,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -32860,7 +32846,6 @@
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -32993,7 +32978,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -33104,7 +33088,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -33239,7 +33222,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -33744,7 +33726,6 @@
       "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "co": "^4.6.0",
         "json-stable-stringify": "^1.0.1"
@@ -34455,7 +34436,6 @@
       "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^5.0.0",
         "acorn-dynamic-import": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -204,6 +204,16 @@
       }
     },
     "cheerio": "1.0.0-rc.3",
-    "fsevents": "2.3.3"
+    "fsevents": "2.3.3",
+    "rest-facade": {
+      "superagent": {
+        "formidable": "2.1.3"
+      }
+    },
+    "auth0-js": {
+      "superagent": {
+        "formidable": "2.1.3"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR fixes the formidable vulnerability by adding overrides to package.json.